### PR TITLE
fix: status updated time + newest manifest per address

### DIFF
--- a/src/helpers/site-index.ts
+++ b/src/helpers/site-index.ts
@@ -33,6 +33,10 @@ export type IndexedSite = {
   snapshots: SiteSnapshotSummary[];
 };
 
+/**
+ * Prefer the newest manifest per address. The naive loop overwrites by timeline order; if the
+ * store yields events out of order, an older manifest could replace a newer one.
+ */
 export function buildIndexedSites(events: NostrEvent[]): IndexedSite[] {
   const sites = new Map<string, IndexedSite>();
   const snapshotsByParent = new Map<string, SiteSnapshotSummary[]>();
@@ -71,6 +75,10 @@ export function buildIndexedSites(events: NostrEvent[]): IndexedSite[] {
       pubkey: event.pubkey,
       identifier: identifier ?? "",
     });
+    const existing = sites.get(key);
+    if (existing && event.created_at < existing.createdAt) {
+      continue;
+    }
     sites.set(key, {
       key,
       pubkey: event.pubkey,

--- a/src/pages/status.tsx
+++ b/src/pages/status.tsx
@@ -30,6 +30,11 @@ function formatTimestamp(createdAt: number): string {
   return new Date(createdAt * 1000).toISOString().replace(".000Z", "Z");
 }
 
+/** Newest of manifest publish time vs latest snapshot (manifest-only republish still moves this). */
+function siteDisplayUpdatedAt(site: StatusSite): number {
+  return Math.max(site.createdAt, site.latestSnapshotCreatedAt ?? 0);
+}
+
 const SiteRow: FC<{ site: StatusSite }> = ({ site }) => {
   const label = site.title || site.identifier ||
     site.npub.slice(0, 8) + "..." + site.npub.slice(-4);
@@ -68,10 +73,8 @@ const SiteRow: FC<{ site: StatusSite }> = ({ site }) => {
           : 0}
       </td>
       <td data-label="hits">{site.hits ?? 0}</td>
-      <td data-label="updated" title={formatTimestamp(site.createdAt)}>
-        {formatAgeFromUnix(
-          site.latestSnapshotCreatedAt ?? site.createdAt,
-        )}
+      <td data-label="updated" title={formatTimestamp(updatedAt)}>
+        {formatAgeFromUnix(updatedAt)}
       </td>
     </tr>
   );


### PR DESCRIPTION
- buildIndexedSites: skip older manifest events for the same address when timeline order is not chronological
- status table: show max(manifest created_at, latest snapshot) so manifest-only republishes advance the updated column


Hey, small fix for the /status “updated” column and how it picks which manifest counts for a site.

Noticed that after republish (new manifest / kind 35128), the status page was unchanged — the time stayed stuck on first publish. Atm its going by snapshot time so the “updated” time never moved even though the manifest’s created_at did.

When building the site list from relay data, whatever manifest event got processed last won — not necessarily the newest one. 

For each site address, I now only keep the manifest with the latest created_at (ignore older duplicates from ordering).
For the “updated” label I use newest manifest time or the latest snapshot time — so manifest-only republishes show up too. No change to how sites are served just better  metadata in the listing.

Im running the same logic from a fork at https://gittr.space/pages
Users can trigger in their repo panel the Readme edit & generation of the manifest and push each as named site and as the one-and-only most actual page. A repush overwrites the old version one the gateways listiing (UI wise).


Good job and Cheers