### PR TITLE
Show nsite deploy clients in status views

### DIFF
--- a/src/helpers/__tests__/site-index.test.ts
+++ b/src/helpers/__tests__/site-index.test.ts
@@ -24,6 +24,7 @@ Deno.test("buildIndexedSites groups snapshots under their parent site", () => {
     tags: [
       ["d", "blog"],
       ["title", "Blog"],
+      ["client", "nsyte"],
       ["path", "/index.html", "2".repeat(64)],
     ],
   });
@@ -53,6 +54,7 @@ Deno.test("buildIndexedSites groups snapshots under their parent site", () => {
   const sites = buildIndexedSites([site, olderSnapshot, newerSnapshot]);
 
   assertEquals(sites.length, 1);
+  assertEquals(sites[0].client, "nsyte");
   assertEquals(sites[0].snapshots.map((snapshot) => snapshot.id), [
     newerSnapshot.id,
     olderSnapshot.id,

--- a/src/helpers/site-index.ts
+++ b/src/helpers/site-index.ts
@@ -1,6 +1,7 @@
 import type { NostrEvent } from "applesauce-core/helpers";
 import {
   getManifestAddressKey,
+  getManifestClient,
   getManifestDescription,
   getManifestIdentifier,
   getManifestPaths,
@@ -27,6 +28,7 @@ export type IndexedSite = {
   kind: number;
   title?: string;
   description?: string;
+  client?: string;
   pathCount: number;
   manifestId: string;
   createdAt: number;
@@ -86,6 +88,7 @@ export function buildIndexedSites(events: NostrEvent[]): IndexedSite[] {
       kind: event.kind,
       title: getManifestTitle(event),
       description: getManifestDescription(event),
+      client: getManifestClient(event),
       pathCount: getManifestPaths(event).size,
       manifestId: event.id,
       createdAt: event.created_at,

--- a/src/helpers/site-manifest.ts
+++ b/src/helpers/site-manifest.ts
@@ -141,3 +141,7 @@ export function getManifestDescription(
 export function getManifestSource(manifest: NostrEvent): string | undefined {
   return getTagValue(manifest, "source");
 }
+
+export function getManifestClient(manifest: NostrEvent): string | undefined {
+  return getTagValue(manifest, "client");
+}

--- a/src/nsite-clients.test.ts
+++ b/src/nsite-clients.test.ts
@@ -1,0 +1,36 @@
+import {
+  getNsiteDeployClientReference,
+  NSITE_DEPLOY_CLIENTS,
+} from "./nsite-clients.ts";
+
+Deno.test("nsite deploy client map starts with nsyte", () => {
+  const firstKey = [...NSITE_DEPLOY_CLIENTS.keys()][0];
+  if (firstKey !== "nsyte") {
+    throw new Error(`Expected first client to be nsyte, got ${firstKey}`);
+  }
+
+  const nsyte = NSITE_DEPLOY_CLIENTS.get("nsyte");
+  if (nsyte?.href !== "https://nsyte.run") {
+    throw new Error(`Expected nsyte href to be https://nsyte.run`);
+  }
+});
+
+Deno.test("getNsiteDeployClientReference links known clients", () => {
+  const client = getNsiteDeployClientReference("nsyte");
+  if (
+    client?.tag !== "nsyte" || client.name !== "nsyte" ||
+    client.href !== "https://nsyte.run"
+  ) {
+    throw new Error(`Expected nsyte client reference with href`);
+  }
+});
+
+Deno.test("getNsiteDeployClientReference preserves unknown client tags", () => {
+  const client = getNsiteDeployClientReference(" custom-cli ");
+  if (
+    client?.tag !== "custom-cli" || client.name !== "custom-cli" ||
+    client.href !== undefined
+  ) {
+    throw new Error(`Expected unknown client tag to be preserved without href`);
+  }
+});

--- a/src/nsite-clients.ts
+++ b/src/nsite-clients.ts
@@ -1,0 +1,36 @@
+export type NsiteDeployClient = {
+  readonly name: string;
+  readonly href: string;
+};
+
+export type NsiteDeployClientReference = {
+  readonly tag: string;
+  readonly name: string;
+  readonly href?: string;
+};
+
+/**
+ * Known nsite deploy clients keyed by the value published in the manifest
+ * `client` tag. Add new client links here to make status pages link them.
+ */
+export const NSITE_DEPLOY_CLIENTS = new Map<string, NsiteDeployClient>([
+  ["nsyte", { name: "nsyte", href: "https://nsyte.run" }],
+]);
+
+function normalizeClientTag(tag: string): string {
+  return tag.trim().toLowerCase();
+}
+
+export function getNsiteDeployClientReference(
+  clientTag: string | undefined,
+): NsiteDeployClientReference | undefined {
+  const tag = clientTag?.trim();
+  if (!tag) return undefined;
+
+  const client = NSITE_DEPLOY_CLIENTS.get(normalizeClientTag(tag));
+  if (client) {
+    return { tag, name: client.name, href: client.href };
+  }
+
+  return { tag, name: tag };
+}

--- a/src/pages/status.tsx
+++ b/src/pages/status.tsx
@@ -2,6 +2,7 @@ import type { FC } from "@hono/hono/jsx";
 import { formatAgeFromUnix } from "../helpers/format.ts";
 import { naddrEncode, neventEncode } from "applesauce-core/helpers";
 import { NAMED_SITE_MANIFEST_KIND } from "../helpers/site-manifest.ts";
+import type { NsiteDeployClientReference } from "../nsite-clients.ts";
 
 export type StatusSite = {
   key: string;
@@ -15,6 +16,7 @@ export type StatusSite = {
   hostname?: string;
   href?: string;
   npub: string;
+  client?: NsiteDeployClientReference;
   authorName?: string;
   hits?: number;
   snapshotCount: number;
@@ -61,6 +63,19 @@ const SiteRow: FC<{ site: StatusSite }> = ({ site }) => {
           {site.authorName ||
             site.npub.slice(0, 8) + "..." + site.npub.slice(-4)}
         </span>
+      </td>
+      <td data-label="client">
+        {site.client
+          ? (
+            site.client.href
+              ? (
+                <a href={site.client.href} title={site.client.tag}>
+                  {site.client.name}
+                </a>
+              )
+              : <span title={site.client.tag}>{site.client.name}</span>
+          )
+          : <span class="none">—</span>}
       </td>
       <td data-label="paths">
         <a href={statusHref}>{pluralize(site.pathCount, "path", "paths")}</a>
@@ -113,6 +128,7 @@ export const StatusPage: FC<{ sites: StatusSite[]; host: string }> = (
               <tr>
                 <th>site</th>
                 <th>author</th>
+                <th>client</th>
                 <th>paths</th>
                 <th>snapshots</th>
                 <th>hits</th>
@@ -123,7 +139,7 @@ export const StatusPage: FC<{ sites: StatusSite[]; host: string }> = (
               {sites.length === 0
                 ? (
                   <tr>
-                    <td colspan={6}>
+                    <td colspan={7}>
                       No sites available through this gateway yet.
                     </td>
                   </tr>

--- a/src/routes/status/site.tsx
+++ b/src/routes/status/site.tsx
@@ -20,6 +20,7 @@ import {
   type SiteSnapshotSummary,
 } from "../../helpers/site-index.ts";
 import {
+  getManifestClient,
   getManifestDescription,
   getManifestPaths,
   getManifestRelays,
@@ -30,6 +31,10 @@ import {
   ROOT_SITE_MANIFEST_KIND,
 } from "../../helpers/site-manifest.ts";
 import { getBlobServer } from "../../services/cache.ts";
+import {
+  getNsiteDeployClientReference,
+  type NsiteDeployClientReference,
+} from "../../nsite-clients.ts";
 import {
   eventStore,
   getManifest,
@@ -165,6 +170,7 @@ const SiteDetailPage: FC<{
   title?: string;
   description?: string;
   source?: string;
+  client?: NsiteDeployClientReference;
   manifestServers: string[];
   userServers: string[];
   relays: string[];
@@ -262,6 +268,21 @@ const SiteDetailPage: FC<{
                 {props.source && (
                   <InfoRow label="source">
                     <a href={props.source}>{props.source}</a>
+                  </InfoRow>
+                )}
+                {props.client && (
+                  <InfoRow label="client">
+                    {props.client.href
+                      ? (
+                        <a href={props.client.href} title={props.client.tag}>
+                          {props.client.name}
+                        </a>
+                      )
+                      : (
+                        <span title={props.client.tag}>
+                          {props.client.name}
+                        </span>
+                      )}
                   </InfoRow>
                 )}
                 <InfoRow label="updated">
@@ -529,6 +550,7 @@ export async function siteStatusRoute(c: Context): Promise<Response> {
   const title = getManifestTitle(manifest);
   const description = getManifestDescription(manifest);
   const source = getManifestSource(manifest);
+  const client = getNsiteDeployClientReference(getManifestClient(manifest));
   const indexedSites = buildIndexedSites(eventStore.getTimeline({}));
   const indexedSite = parsed.type === "replaceable"
     ? indexedSites.find((site) =>
@@ -611,6 +633,7 @@ export async function siteStatusRoute(c: Context): Promise<Response> {
           title={title}
           description={description}
           source={source}
+          client={client}
           manifestServers={manifestServers}
           userServers={userServers ?? []}
           relays={relays}

--- a/src/routes/status/status.tsx
+++ b/src/routes/status/status.tsx
@@ -7,6 +7,7 @@ import { eventStore, getUserProfile } from "../../services/nostr.ts";
 import { npubEncode } from "applesauce-core/helpers";
 import { StatusPage, type StatusSite } from "../../pages/status.tsx";
 import { getHitCount } from "../../services/analytics.ts";
+import { getNsiteDeployClientReference } from "../../nsite-clients.ts";
 
 function getStatusSites(host: string, protocol: string): StatusSite[] {
   const muted = getCurationMutedPubkeys();
@@ -30,6 +31,7 @@ function getStatusSites(host: string, protocol: string): StatusSite[] {
       hostname: siteHostname,
       href: siteHostname ? `${protocol}//${siteHostname}/` : undefined,
       npub: npubEncode(site.pubkey),
+      client: getNsiteDeployClientReference(site.client),
       snapshotCount: site.snapshots.length,
       latestSnapshotId: site.snapshots[0]?.id,
       latestSnapshotCreatedAt: site.snapshots[0]?.createdAt,


### PR DESCRIPTION
## Summary
- add a visible deploy-client registry with `nsyte` linked to https://nsyte.run
- parse the manifest `client` tag into indexed site summaries
- show the deploy client in `/status` and `/status/:address`, linking known clients and preserving unknown tags as text

## Validation
- `deno task check`
- `deno fmt --check` on changed files
- `deno test --allow-all src`
- `deno lint` on changed production files and `src/nsite-clients.test.ts`

Note: full `deno lint src main.ts` still reports unrelated existing lint debt in legacy tests/services/pages.