### PR TITLE
Skip hostname resolution for gateway root hosts

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -52,12 +52,14 @@ app.use(
 
 app.all("*", async (c) => {
   const hostname = new URL(c.req.url).hostname;
-  const pointer = await resolvePubkeyFromHostname(hostname);
-  if (pointer) {
-    return await handleSiteRequest(c, pointer);
-  }
 
+  // Root hosts are already known locally; only resolve potential site hostnames.
   if (!isGatewayRootHost(hostname)) {
+    const pointer = await resolvePubkeyFromHostname(hostname);
+    if (pointer) {
+      return await handleSiteRequest(c, pointer);
+    }
+
     return c.html(
       html`
         <!DOCTYPE html>${InvalidAddress({ hostname })}


### PR DESCRIPTION
`resolvePubkeyFromHostname()` ran on every request, including requests to `PUBLIC_DOMAIN` itself, performing a CNAME lookup that is unnecessary for hosts already known to be the gateway root (`localhost`, `NSITE_HOST`, `PUBLIC_DOMAIN`, `ONION_HOST`).

On hosts where Deno's resolver cannot complete the query (e.g. systemd-resolved stub on `127.0.0.53`), `Deno.resolveDns` times out after 15s, so **every** request to the gateway homepage took ~16s:

```
$ deno eval 'await Deno.resolveDns("nsite.jbnco.co","CNAME")'
error: proto error: request timed out after 15006 ms
```

This change checks `isGatewayRootHost()` first and only resolves potential site hostnames. Behavior for actual site hostnames (npub subdomains, snapshot labels, named sites, custom CNAMEs) is unchanged.

Measured before/after on my gateway (nsite.jbnco.co): homepage 15.9s → 0.9s.