### PR TITLE
fix: prefer path-derived MIME type over the blossom server's content-type header

### DIFF
--- a/src/routes/site.tsx
+++ b/src/routes/site.tsx
@@ -147,13 +147,18 @@ export async function handleSiteRequest(
 
   // Create response headers
   const headers = new Headers();
+  // Prefer the MIME type implied by the request path. Blossom stores blobs
+  // without content types, so upstream servers guess -- often text/plain --
+  // and browsers refuse a stylesheet served as text/plain, leaving sites
+  // unstyled. The path extension is the only type signal the site author
+  // controls; fall back to the upstream header only when the path has no
+  // known extension.
   const upstreamContentType = upstream.headers.get("content-type");
-  const upstreamContentLength = upstream.headers.get("content-length");
-  if (upstreamContentType) {
+  const pathMime = contentType(extname(match.path));
+  if (pathMime) {
+    headers.set("content-type", pathMime);
+  } else if (upstreamContentType) {
     headers.set("content-type", upstreamContentType);
-  } else if (!upstreamContentLength) {
-    const mime = contentType(extname(match.path));
-    if (mime) headers.set("content-type", mime);
   }
 
   // Copy response headers from the upstream response


### PR DESCRIPTION
## Problem

Blossom servers store blobs without content types, so the `content-type` header they return on retrieval is a guess. Some servers sniff the blob and answer `text/plain` for CSS/JS. `site.tsx` currently prefers that upstream header over the path-derived MIME type, so a stylesheet can be served as `text/plain` -- and browsers then refuse to apply it, rendering the whole nsite unstyled.

Observed in production: the same npub renders styled on gateways that infer MIME from the request path and unstyled on gateways that trust the blob server's header.

## Fix

Prefer the MIME type implied by the request path extension -- the only type signal the site author actually controls -- and fall back to the upstream header only when the path has no known extension. The existing extension fallback already existed; this just inverts the precedence.

## Testing

Running this patch on a self-hosted instance: `/output.css` now serves `text/css; charset=UTF-8` (was `text/plain`), `/manifest.json` serves `application/json`, HTML and extensionless paths unchanged.

---
_This PR was prepared with AI assistance and reviewed before submission._